### PR TITLE
Step14: Cache and Redis Implementation

### DIFF
--- a/week03_concert/docs/STEP13_REPORT.MD
+++ b/week03_concert/docs/STEP13_REPORT.MD
@@ -1,0 +1,143 @@
+# 캐싱 분석 리포트
+
+## 캐싱 공부 내용
+### 알게된 점
+- 캐싱이 적용된 데이터는 데이터의 정확도를 보장할 수 없다
+  - DB에 저장된 영속 데이터와 시간 차이로 인해 데이터가 정확히 일치되지는 않는다
+  - 따라서 실시간성이 극도로 중요한 곳에는 이용하지 않는 것이 바람직할 수 있다
+- 캐싱을 적용하는 주된 이유는 '순간적인 부하 감소'이다
+  - 캐싱은 데이터를 일정 시간동안만 저장했다가 그 자료를 응답한다
+  - 따라서 평상시보다는, 데이터가 몰리는 피크타임 때 빛을 발한다
+- 피크타임때 캐싱의 유용성
+  - 서버 트래픽이 과도해지는 이유는 대부분 순간 트래픽이 몰려서이다
+  - 따라서 캐싱은 부하 피크 상태에 중점을 둔다면 더 용이하게 쓸 수 있다
+- 물론 평상시에도 캐싱이 유용할 때가 있다
+  - 추천 알고리즘과 같은 몇몇 로직은 기본적으로 부하가 클 수 있다
+  - 따라서 이런 일시적이면서도 부하가 높은 로직을 대상으로 유용할 수 있다
+
+### 캐싱 전략 분석
+#### 읽기
+- Look Aside
+  - 캐시 확인
+  - miss시 db에 접근
+- Read Through
+  - 캐시 확인
+  - miss시 redis가 db로부터 업데이트
+#### 쓰기
+- Write Back
+  - 업데이트 내역을 일단 캐시에 보관
+  - 한 번씩 db에 저장
+- Write Through
+  - 캐시에 저장
+  - redis가 알아서 db에 저장
+- Write Around
+  - db에 저장
+  - 캐시도 같이 삭제 또는 변경
+
+## 캐싱 적용 가능 로직 분석
+### 대기열
+#### 적용 이유
+- 대기열 토큰은 서버에 접근하기 위한 임시 토큰
+  - 토큰이 사라져도 재발급에 큰 무리가 없음
+- 이용량이 매우 높음
+  - 모든 콘서트 api 접근시에 필요
+  - 매우 높은 사용 빈도 발생
+- 따라서 Redis에서만 관리해도 무리가 없는 데이터이기에 DB와 분리시키면 효율성 증가 가능
+
+#### 적용 방법
+- 성능 측정 테스트 우선 작성 `performance/CacheTest.java`
+  - 아래 함수의 실행 시간을 측정
+```java
+List<CompletableFuture<String>> tasks = IntStream.range(0, numOfUsers)
+      .<CompletableFuture<String>>mapToObj( i -> CompletableFuture.supplyAsync(() -> {
+          Long userId = users.get(i).getId();
+
+          UUID token = tokenFacade.issue(userId).getToken();
+          while (true) {
+              try {
+                  tokenFacade.refreshTokenQueue(1);
+                  tokenFacade.check(userId, token.toString());
+                  break;
+              } catch (Exception ignored) {
+                  log.info(ignored.getMessage());
+              }
+
+              try {
+                  Thread.sleep(1000);
+              } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+              }
+          }
+
+          return null;
+      })).toList();
+```
+- Infra 레이어를 Redis로 교체
+  - 기존 환경 : `TokenRepository` 는 JPA interface를 상속
+  - 변경 :
+    - `TokenRepository`를 pure한 interface로 변경
+    - `TokenRepository`를 상속받는 `TokenRepositoryRedisImpl` 제작 및 Primary Bean 등록
+
+#### 레디스 적용 후기
+- 성능 측정
+  - 3000명의 유저가 토큰을 발급하고, token이 active될 때 까지 대기(activation은 token 발급과 동시에 수행)
+  - 기존 대비 **50%** 이상 성능 향상
+  - AS-IS(RDB) : ```Total time: 19927 ms```
+  - TO-BE(Redis) : ```Total time: 8213 ms```
+- 클린아키텍처
+  - Service의 변경 없이 Infra 구성 변경만으로 Redis 적용 가능했음
+  - 그러나 성능 향상을 더 끌어올리기 위해서는 redis에 맞게 infra 코드를 튜닝해야 할 것 같음
+
+#### 향후 확장 가능성
+- K6, JMeter, NGrinder 등을 이용한 부하 분석 실행 가능
+- Redis 적용에 따른 성능 튜닝 가능
+  - 현재 코드는 JPA 기반 기존 로직을 그대로 활용
+  - 인프라만 JPA에서 Redis 구현체로 교체됨
+  - 따라서 Redis의 기능을 더 잘 활용할 수 있는 가능성 열려있음(status 전환을 한 함수에서 진행하는 등)
+
+### 시간대별 잔여좌석 갯수
+#### 적용 이유
+- 시간대별 잔여좌석 수는 실시간성 보장 필요 없음
+  - 이용자 흐름을 보면, 잔여좌석 수 확인 후에 좌석 선택으로 넘어감
+  - 그 사이에 시간간격이 있다는 것을 이용자도 알기에 정확한 데이터를 넘겨줄 필요는 없음
+- 이용량이 비교적 높음
+  - 콘서트 예매 이용자가 모두 거쳐가는 유즈케이스
+  - 예매가 몰리는 시간대에 트래픽이 몰릴 수 있음
+- 따라서 캐싱을 통해 사용자 경험을 해치지 않으며 DB 부하를 줄일 수 있음
+
+#### 적용 방법
+- 성능 측정 테스트 우선 작성 `performance/CacheTest.java`
+  - 아래 함수의 실행 시간을 측정
+```java
+for (int i = 0; i < numOfViews; i++) {
+    concertFacade.findConcertTimeslots(concertId);
+}
+```
+- Spring `@Cachable`을 이용하여 캐시 적용
+  - `RedisCacheConfig` 적용하여 Cacheable 로드
+  - `@Cacheable(value = "concert:timeslot", key = "#concertId", cacheManager = "redisCacheManager")`
+  - TTL은 3초로 세팅했으나, 글로벌 값으로 지정되어 있기 때문에 별도 ttl 적용방법 찾아야 할 듯
+
+#### 캐시 적용 후기(성능)
+- 10,000번의 concert timeslot 조회를 수행
+- 기존 대비 **90%** 이상 성능 향상
+- AS-IS : ```Total time: 21782 ms```
+- TO-BE : ```Total time: 2773 ms```
+
+#### 향후 확장 가능성
+- 캐시별 별도의 ttl을 구성할 수 있는 방법 찾아봐야 할 듯
+
+## 이외에도 캐싱 적용 가능한 API에 대한 고찰
+- 캐싱은 주로 부하를 많이 차지하면서 실시간성에서 자유로운 로직에 대해 수행하면 효율적일 것 같음
+- 아래의 기능이 있다면, 캐싱 적용이 유리하다고 생각
+  - 주간, 일간, 월간 콘서트 랭킹
+    - 리프레시되는 시간이 매우 길다
+    - 집계하는 연산 비용이 매우 높다
+  - 개인 추천 콘텐츠
+    - 추천 알고리즘의 연산 비용이 매우 높다
+    - 그러나 유저가 다양한 추천 콘텐츠를 원할 수 있으므로, 미리 여러 목록을 뽑아놓고 랜덤으로 보여주는 것도 괜찮을 것 같다
+  - 공지사항
+    - 유저가 콘서트 취소 같은 알림을 받으면 유저가 몰릴 가능성이 존재한다
+    - 공지사항이 수정될 수도 있긴 하지만, 이는 알림을 통해 재전달되기에 유저가 변경 여부를 파악할 수 있다
+    - TTL을 짧게 10초정도로 잡는다면, 부하에 대비하면서도 어느정도의 실시간성을 가져갈 수 있다
+    - 혹은 공지사항이 자주 변경되지는 않으므로 동시성 문제에서 자유롭다. 따라서 공지사항 변경시 캐시 업데이트도 즉시 수행해도 될 것 같다.

--- a/week03_concert/src/main/java/com/example/concert/ConcertApplication.java
+++ b/week03_concert/src/main/java/com/example/concert/ConcertApplication.java
@@ -2,7 +2,9 @@ package com.example.concert;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class ConcertApplication {
 

--- a/week03_concert/src/main/java/com/example/concert/common/config/RedisCacheConfig.java
+++ b/week03_concert/src/main/java/com/example/concert/common/config/RedisCacheConfig.java
@@ -1,0 +1,33 @@
+package com.example.concert.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory cf) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper))) // Value Serializer 변경
+                .entryTtl(Duration.ofSeconds(3)); // 캐시 수명 30분
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+    }
+}

--- a/week03_concert/src/main/java/com/example/concert/common/scheduler/Scheduler.java
+++ b/week03_concert/src/main/java/com/example/concert/common/scheduler/Scheduler.java
@@ -2,27 +2,23 @@ package com.example.concert.common.scheduler;
 
 import com.example.concert.token.TokenFacade;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 @Component
 @Profile("!test")
 @Slf4j
+@RequiredArgsConstructor
 public class Scheduler {
 
-    public Scheduler(TokenFacade tokenFacade) {
-        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private TokenFacade tokenFacade;
 
-        Runnable task = () -> {
-            tokenFacade.refreshTokenQueue(5);
-            log.info("Token refreshed");
-        };
-
-        scheduler.scheduleAtFixedRate(task, 0, 1, TimeUnit.SECONDS);
+    @Scheduled(fixedDelay = 1000)
+    private void tokenScheduler() {
+        tokenFacade.refreshTokenQueue(5);
+        log.info("Token refreshed");
     }
 }

--- a/week03_concert/src/main/java/com/example/concert/concert/ConcertFacade.java
+++ b/week03_concert/src/main/java/com/example/concert/concert/ConcertFacade.java
@@ -12,6 +12,7 @@ import com.example.concert.user.UserService;
 import com.example.concert.user.domain.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -38,6 +39,7 @@ public class ConcertFacade {
         return concertService.createConcertSeats(concertTimeslotId, price, seatIds);
     }
 
+    @Cacheable(value = "concert:timeslot", key = "#concertId", cacheManager = "redisCacheManager")
     public List<ConcertTimeslotWithOccupancy> findConcertTimeslots(Long concertId) {
         Concert concert = concertService.findConcert(concertId);
 

--- a/week03_concert/src/main/java/com/example/concert/concert/dto/ConcertTimeslotWithOccupancy.java
+++ b/week03_concert/src/main/java/com/example/concert/concert/dto/ConcertTimeslotWithOccupancy.java
@@ -1,5 +1,6 @@
 package com.example.concert.concert.dto;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ConcertTimeslotWithOccupancy(
@@ -9,5 +10,5 @@ public record ConcertTimeslotWithOccupancy(
         LocalDateTime reservationStartTime,
         Integer maxSeatAmount,
         Integer occupiedSeatAmount
-) {
+) implements Serializable {
 }

--- a/week03_concert/src/main/java/com/example/concert/token/TokenService.java
+++ b/week03_concert/src/main/java/com/example/concert/token/TokenService.java
@@ -22,6 +22,7 @@ public class TokenService {
         LocalDateTime now = LocalDateTime.now();
 
         Token token = Token.builder()
+                .token(UUID.randomUUID())
                 .userId(userId)
                 .status(TokenStatus.WAIT)
                 .createdAt(now)
@@ -52,6 +53,7 @@ public class TokenService {
             Optional<Token> token = this.tokenRepository.findTopByStatusEqualsOrderByCreatedAtDesc(TokenStatus.WAIT);
             if (token.isPresent()) {
                 token.get().activate(now);
+                this.tokenRepository.save(token.get());
             } else {
                 break;
             }

--- a/week03_concert/src/main/java/com/example/concert/token/domain/Token.java
+++ b/week03_concert/src/main/java/com/example/concert/token/domain/Token.java
@@ -7,9 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -18,10 +17,10 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Token {
+public class Token implements Serializable {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
+//    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID token;
 
     @Column(unique = true)

--- a/week03_concert/src/main/java/com/example/concert/token/domain/TokenRepository.java
+++ b/week03_concert/src/main/java/com/example/concert/token/domain/TokenRepository.java
@@ -1,23 +1,13 @@
 package com.example.concert.token.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface TokenRepository extends JpaRepository<Token, Long> {
+//public interface TokenRepository extends JpaRepository<Token, Long> {
+public interface TokenRepository {
+    Token save(Token token);
     Optional<Token> findByToken(UUID token);
-    Optional<Token> findByUserId(Long userId);
-    Integer countAllByStatusIs(TokenStatus status);
     Optional<Token> findTopByStatusEqualsOrderByCreatedAtDesc(TokenStatus status);
-
-    @Query("""
-        UPDATE Token t
-        SET t.status="EXPIRED"
-        WHERE :dtime < CURRENT_TIMESTAMP
-    """)
-    void updateAllByCreatedAtBeforeToExpired(@Param("dtime") LocalDateTime decisionTime);
 }

--- a/week03_concert/src/main/java/com/example/concert/token/infra/TokenRepositoryRedisImpl.java
+++ b/week03_concert/src/main/java/com/example/concert/token/infra/TokenRepositoryRedisImpl.java
@@ -1,0 +1,83 @@
+package com.example.concert.token.infra;
+
+import com.example.concert.token.domain.Token;
+import com.example.concert.token.domain.TokenRepository;
+import com.example.concert.token.domain.TokenStatus;
+import org.redisson.api.RMap;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+@Primary
+@Component
+//public class TokenRepositoryRedisImpl {
+public class TokenRepositoryRedisImpl implements TokenRepository {
+
+    public TokenRepositoryRedisImpl(RedissonClient redissonClient) {
+        this.tokenMap = redissonClient.getMap("token");
+        this.waitingSet = redissonClient.getScoredSortedSet("token:wait");
+        this.activeSet = redissonClient.getScoredSortedSet("token:active");
+    }
+
+    private final RMap<String, Token> tokenMap;
+    private final RScoredSortedSet<String> waitingSet;
+    private final RScoredSortedSet<String> activeSet;
+
+    public Token save(Token token) {
+        long timeStamp = dateTimeToTimestamp(token.getUpdatedAt());
+        switch (token.getStatus()) {
+            case WAIT:
+                tokenMap.put(token.getToken().toString(), token);
+                waitingSet.add(timeStamp, token.getToken().toString());
+                activeSet.remove(token.getToken().toString());
+                break;
+            case ACTIVE:
+                tokenMap.put(token.getToken().toString(), token);
+                activeSet.add(timeStamp, token.getToken().toString());
+                waitingSet.remove(token.getToken().toString());
+                break;
+            case EXPIRED:
+                tokenMap.remove(token.getToken().toString());
+                waitingSet.remove(token.getToken().toString());
+                activeSet.remove(token.getToken().toString());
+        }
+        return token;
+    }
+
+    public Optional<Token> findByToken(UUID token) {
+        return Optional.ofNullable(tokenMap.get(token.toString()));
+    }
+
+    public Optional<Token> findTopByStatusEqualsOrderByCreatedAtDesc(TokenStatus status) {
+        switch (status) {
+            case WAIT:
+                String waitTokenString = waitingSet.pollFirst();
+                if (waitTokenString == null) {
+                    break;
+                }
+                Token waitToken = tokenMap.get(waitTokenString);
+                return Optional.ofNullable(waitToken);
+            case ACTIVE:
+                String activeTokenString = activeSet.pollFirst();
+                if (activeTokenString == null) {
+                    break;
+                }
+                Token activeToken = tokenMap.get(activeTokenString);
+                return Optional.ofNullable(activeToken);
+            case EXPIRED:
+                return Optional.empty();
+        }
+        return Optional.empty();
+    }
+
+    private long dateTimeToTimestamp(LocalDateTime dateTime) {
+        ZoneOffset offset = ZoneOffset.UTC;
+        return dateTime.toEpochSecond(offset);
+    }
+}

--- a/week03_concert/src/test/java/com/example/concert/TestEnv.java
+++ b/week03_concert/src/test/java/com/example/concert/TestEnv.java
@@ -1,0 +1,22 @@
+package com.example.concert;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestContainerConfig.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class TestEnv {
+    @Autowired private RedissonClient redissonClient;
+
+    @BeforeEach
+    protected void setUp() {
+        System.out.println("sdlifjslidfjlsidjlifjsildjlf");
+        redissonClient.getKeys().flushdb();
+        redissonClient.getKeys().flushall();
+    }
+}

--- a/week03_concert/src/test/java/com/example/concert/e2e/ApiTest.java
+++ b/week03_concert/src/test/java/com/example/concert/e2e/ApiTest.java
@@ -1,5 +1,6 @@
 package com.example.concert.e2e;
 
+import com.example.concert.TestEnv;
 import com.example.concert.TestContainerConfig;
 import com.example.concert.balance.api.BalanceControllerDTO;
 import com.example.concert.concert.ConcertFacade;
@@ -26,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestContainerConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class ApiTest {
+public class ApiTest extends TestEnv {
 
     @LocalServerPort
     private int port;
@@ -41,7 +42,8 @@ public class ApiTest {
     List<Long> concertSeatIds;
 
     @BeforeEach
-    void setUp() {
+    protected void setUp() {
+        super.setUp();
         this.userId = this.userFacade.createUser("user aaa").getId();
         this.concertId = this.concertFacade.createConcert("아이유 연말콘서트").getId();
         this.concertTimeslotId = this.concertFacade.createConcertTimeslot(

--- a/week03_concert/src/test/java/com/example/concert/e2e/FilterTest.java
+++ b/week03_concert/src/test/java/com/example/concert/e2e/FilterTest.java
@@ -1,6 +1,6 @@
 package com.example.concert.e2e;
 
-import com.example.concert.TestContainerConfig;
+import com.example.concert.TestEnv;
 import com.example.concert.common.error.CommonErrorCode;
 import com.example.concert.concert.ConcertFacade;
 import com.example.concert.concert.domain.concertseat.ConcertSeat;
@@ -12,22 +12,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(TestContainerConfig.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class FilterTest {
+public class FilterTest extends TestEnv {
 
     @LocalServerPort
     private int port;
@@ -42,7 +35,8 @@ public class FilterTest {
     List<Long> concertSeatIds;
 
     @BeforeEach
-    void setUp() {
+    protected void setUp() {
+        super.setUp();
         this.userId = this.userFacade.createUser("user aaa").getId();
         this.concertId = this.concertFacade.createConcert("아이유 연말콘서트").getId();
         this.concertTimeslotId = this.concertFacade.createConcertTimeslot(

--- a/week03_concert/src/test/java/com/example/concert/integration/ConcurrencyTest.java
+++ b/week03_concert/src/test/java/com/example/concert/integration/ConcurrencyTest.java
@@ -1,6 +1,6 @@
 package com.example.concert.integration;
 
-import com.example.concert.TestContainerConfig;
+import com.example.concert.TestEnv;
 import com.example.concert.balance.BalanceFacade;
 import com.example.concert.balance.domain.balance.BalanceRepository;
 import com.example.concert.balance.domain.balancehistory.BalanceHistory;
@@ -13,10 +13,7 @@ import com.example.concert.user.domain.User;
 import com.example.concert.concert.domain.concertseat.ConcertSeat;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,10 +24,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
-@Import(TestContainerConfig.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class ConcurrencyTest {
+public class ConcurrencyTest extends TestEnv {
 
     @Autowired private BalanceHistoryRepository balanceHistoryRepository;
     @Autowired private BalanceRepository balanceRepository;
@@ -43,7 +37,8 @@ public class ConcurrencyTest {
     Long concertTimeslotId;
 
     @BeforeEach
-    void setUp() {
+    protected void setUp() {
+        super.setUp();
         this.concertId = this.concertFacade.createConcert("아이유 연말콘서트").getId();
         this.concertTimeslotId = this.concertFacade.createConcertTimeslot(
                 this.concertId,

--- a/week03_concert/src/test/java/com/example/concert/integration/ScenarioTest.java
+++ b/week03_concert/src/test/java/com/example/concert/integration/ScenarioTest.java
@@ -1,6 +1,6 @@
 package com.example.concert.integration;
 
-import com.example.concert.TestContainerConfig;
+import com.example.concert.TestEnv;
 import com.example.concert.balance.BalanceFacade;
 import com.example.concert.balance.domain.balancehistory.BalanceHistoryRepository;
 import com.example.concert.common.error.CommonException;
@@ -12,19 +12,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
-@Import(TestContainerConfig.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class ScenarioTest {
+public class ScenarioTest extends TestEnv {
 
     @Autowired private BalanceHistoryRepository balanceHistoryRepository;
 
@@ -39,7 +33,8 @@ public class ScenarioTest {
     Long concertSeatId;
 
     @BeforeEach
-    void setUp() {
+    protected void setUp() {
+        super.setUp();
         this.userId = this.userFacade.createUser("user name").getId();
         this.concertId = this.concertFacade.createConcert("아이유 연말콘서트").getId();
         this.concertTimeslotId = this.concertFacade.createConcertTimeslot(

--- a/week03_concert/src/test/java/com/example/concert/performance/CacheTest.java
+++ b/week03_concert/src/test/java/com/example/concert/performance/CacheTest.java
@@ -1,17 +1,17 @@
 package com.example.concert.performance;
 
 import com.example.concert.TestEnv;
-import com.example.concert.common.error.CommonException;
+import com.example.concert.concert.ConcertFacade;
 import com.example.concert.token.TokenFacade;
 import com.example.concert.user.UserFacade;
 import com.example.concert.user.domain.User;
 import groovy.util.logging.Slf4j;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -23,11 +23,12 @@ public class CacheTest extends TestEnv {
     private static final Logger log = LoggerFactory.getLogger(CacheTest.class);
     @Autowired private UserFacade userFacade;
     @Autowired private TokenFacade tokenFacade;
+    @Autowired private ConcertFacade concertFacade;
 
     @Test
-    void token_100Users() {
+    void token_10000Users() {
         // Given
-        int numOfUsers = 1000;
+        int numOfUsers = 3000;
         List<User> users = IntStream.range(0, numOfUsers)
                 .mapToObj( i -> userFacade.createUser(String.valueOf(i)))
                 .toList();
@@ -60,6 +61,28 @@ public class CacheTest extends TestEnv {
         CompletableFuture
                 .allOf(tasks.toArray(new CompletableFuture[0]))
                 .join();
+        long endTime = System.currentTimeMillis();
+
+        // Then
+        log.info("Total time: {} ms", endTime - startTime);
+    }
+
+    @Test
+    void concert_viewTimeslots_10000() {
+        // Given
+        int numOfViews = 10000;
+        Long concertId = this.concertFacade.createConcert("아이유 연말콘서트").getId();
+        Long concertTimeslotId = this.concertFacade.createConcertTimeslot(
+                concertId,
+                LocalDateTime.now().plusMonths(1),
+                LocalDateTime.now().minusMonths(1)
+        ).getId();
+
+        // When
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i < numOfViews; i++) {
+            concertFacade.findConcertTimeslots(concertId);
+        }
         long endTime = System.currentTimeMillis();
 
         // Then

--- a/week03_concert/src/test/java/com/example/concert/performance/CacheTest.java
+++ b/week03_concert/src/test/java/com/example/concert/performance/CacheTest.java
@@ -1,0 +1,68 @@
+package com.example.concert.performance;
+
+import com.example.concert.TestEnv;
+import com.example.concert.common.error.CommonException;
+import com.example.concert.token.TokenFacade;
+import com.example.concert.user.UserFacade;
+import com.example.concert.user.domain.User;
+import groovy.util.logging.Slf4j;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+@Slf4j
+public class CacheTest extends TestEnv {
+
+    private static final Logger log = LoggerFactory.getLogger(CacheTest.class);
+    @Autowired private UserFacade userFacade;
+    @Autowired private TokenFacade tokenFacade;
+
+    @Test
+    void token_100Users() {
+        // Given
+        int numOfUsers = 1000;
+        List<User> users = IntStream.range(0, numOfUsers)
+                .mapToObj( i -> userFacade.createUser(String.valueOf(i)))
+                .toList();
+
+        // When
+        long startTime = System.currentTimeMillis();
+        List<CompletableFuture<String>> tasks = IntStream.range(0, numOfUsers)
+                .<CompletableFuture<String>>mapToObj( i -> CompletableFuture.supplyAsync(() -> {
+                    Long userId = users.get(i).getId();
+
+                    UUID token = tokenFacade.issue(userId).getToken();
+                    while (true) {
+                        try {
+                            tokenFacade.refreshTokenQueue(1);
+                            tokenFacade.check(userId, token.toString());
+                            break;
+                        } catch (Exception ignored) {
+                            log.info(ignored.getMessage());
+                        }
+
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    return null;
+                })).toList();
+        CompletableFuture
+                .allOf(tasks.toArray(new CompletableFuture[0]))
+                .join();
+        long endTime = System.currentTimeMillis();
+
+        // Then
+        log.info("Total time: {} ms", endTime - startTime);
+    }
+}


### PR DESCRIPTION
_코드 작성 후 보고서가 작성되어 Step13, Step14의 내용이 같아졌습니다. 참고해서 봐주시면 감사드리겠습니다_

더 자세한 내용은 보고서에 포함되어있습니다.
[STEP13_REPORT.MD 바로가기](https://github.com/JayHarrisonAhn/hhplus-assignment-tdd/blob/step14/week03_concert/docs/STEP13_REPORT.MD)

### 성능 측정 결과
#### 대기열
- 적용
  - Waiting Token과 Activate Token을 SortedSet으로 구현
  - 상세 토큰 정보는 Map으로 구현
- 성능
  - 3000명의 유저가 토큰을 발급하고, token이 active될 때 까지 대기(activation은 token 발급과 동시에 수행)
  - AS-IS(RDB) : ```Total time: 19927 ms```
  - TO-BE(Redis) : ```Total time: 8213 ms```

#### 콘서트 Timeslot 잔여좌석 수 조회
- 적용
  - 잔여좌석 수를 Redis에 캐시
- 성능
  - 10,000번의 concert timeslot 조회를 수행
  - AS-IS : ```Total time: 21782 ms```
  - TO-BE : ```Total time: 2773 ms```

~JMeter까지는 해보고 싶었지만.. 금요일 면접에 집중하기 위해 나중에 시도해보겠습니다..ㅠㅠ~