### PR TITLE
Step17: Implemented Kafka

### DIFF
--- a/week03_concert/build.gradle.kts
+++ b/week03_concert/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.kafka:spring-kafka")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
 	implementation("org.redisson:redisson-spring-boot-starter:3.37.0")
 
@@ -39,6 +40,8 @@ dependencies {
 	testImplementation("org.testcontainers:junit-jupiter:1.20.2")
 	testImplementation("org.testcontainers:mariadb:1.20.2")
 	testImplementation("io.rest-assured:rest-assured:5.5.0")
+	testImplementation("org.testcontainers:kafka:1.20.3")
+	testImplementation("org.springframework.kafka:spring-kafka-test:3.+")
 
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testRuntimeOnly("org.mariadb.jdbc:mariadb-java-client")

--- a/week03_concert/dev-docker-compose.yml
+++ b/week03_concert/dev-docker-compose.yml
@@ -16,3 +16,26 @@ services:
     image: redis
     ports:
       - 6379:6379
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    ports:
+      - '32181:32181'
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - '9092:9092'
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:32181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-1:29092,EXTERNAL://localhost:9092
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_NUM_PARTITIONS: 3

--- a/week03_concert/src/main/java/com/example/concert/common/config/KafkaConsumerConfig.java
+++ b/week03_concert/src/main/java/com/example/concert/common/config/KafkaConsumerConfig.java
@@ -1,0 +1,46 @@
+package com.example.concert.common.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS_CONFIG;
+
+    public Map<String, Object> consumerConfig() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS_CONFIG);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "group_id");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+        return props;
+    }
+
+    public DefaultKafkaConsumerFactory<String, Object> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfig());
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/week03_concert/src/main/java/com/example/concert/common/config/KafkaProducerConfig.java
+++ b/week03_concert/src/main/java/com/example/concert/common/config/KafkaProducerConfig.java
@@ -20,7 +20,7 @@ public class KafkaProducerConfig {
 
     private final Environment env;
 
-    @Value("${spring.kafka.producer.bootstrap-servers}")
+    @Value("${spring.kafka.bootstrap-servers}")
     private String BOOTSTRAP_SERVERS_CONFIG;
 
     public Map<String, Object> producerConfig() {

--- a/week03_concert/src/main/java/com/example/concert/common/config/KafkaProducerConfig.java
+++ b/week03_concert/src/main/java/com/example/concert/common/config/KafkaProducerConfig.java
@@ -1,0 +1,45 @@
+package com.example.concert.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaProducerConfig {
+
+    private final Environment env;
+
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS_CONFIG;
+
+    public Map<String, Object> producerConfig() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS_CONFIG);
+
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG
+                , StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG
+                , StringSerializer.class);
+        return props;
+    }
+
+    public ProducerFactory<String, String> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(this.producerConfig());
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(this.producerFactory());
+    }
+}

--- a/week03_concert/src/main/java/com/example/concert/common/config/KafkaProducerConfig.java
+++ b/week03_concert/src/main/java/com/example/concert/common/config/KafkaProducerConfig.java
@@ -6,10 +6,10 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,28 +18,23 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class KafkaProducerConfig {
 
-    private final Environment env;
-
     @Value("${spring.kafka.bootstrap-servers}")
     private String BOOTSTRAP_SERVERS_CONFIG;
 
     public Map<String, Object> producerConfig() {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS_CONFIG);
-
-        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG
-                , StringSerializer.class);
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG
-                , StringSerializer.class);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         return props;
     }
 
-    public ProducerFactory<String, String> producerFactory() {
+    public ProducerFactory<String, Object> producerFactory() {
         return new DefaultKafkaProducerFactory<>(this.producerConfig());
     }
 
     @Bean
-    public KafkaTemplate<String, String> kafkaTemplate() {
+    public KafkaTemplate<String, Object> kafkaTemplate() {
         return new KafkaTemplate<>(this.producerFactory());
     }
 }

--- a/week03_concert/src/main/java/com/example/concert/concert/ConcertFacade.java
+++ b/week03_concert/src/main/java/com/example/concert/concert/ConcertFacade.java
@@ -15,6 +15,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -30,7 +31,7 @@ public class ConcertFacade {
     private final UserService userService;
     private final BalanceService balanceService;
 
-    private final ApplicationEventPublisher eventPublisher;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     public Concert createConcert(String name) {
         return concertService.createConcert(name);
@@ -66,7 +67,8 @@ public class ConcertFacade {
         ConcertTimeslotOccupancy timeslotOccupancy = concertService.findConcertTimeslotOccupancy(seat.getConcertTimeslotId());
         timeslotOccupancy.increaseOccupiedSeatAmount();
 
-        eventPublisher.publishEvent(
+        kafkaTemplate.send(
+                "concert.seat-occupy",
                 new ConcertSeatOccupyEvent(tokenString)
         );
 

--- a/week03_concert/src/main/java/com/example/concert/token/TokenFacade.java
+++ b/week03_concert/src/main/java/com/example/concert/token/TokenFacade.java
@@ -5,10 +5,7 @@ import com.example.concert.token.domain.Token;
 import com.example.concert.user.UserService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -34,11 +31,7 @@ public class TokenFacade {
         this.tokenService.activateTokens(amount);
     }
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void expireToken(ConcertSeatOccupyEvent concertSeatOccupyEvent) {
-        concertSeatOccupyEvent
-                .tokenString()
-                .ifPresent(this.tokenService::expireToken);
+    public void expireToken(String tokenString) {
+        this.tokenService.expireToken(tokenString);
     }
 }

--- a/week03_concert/src/main/java/com/example/concert/token/event/TokenEventHandler.java
+++ b/week03_concert/src/main/java/com/example/concert/token/event/TokenEventHandler.java
@@ -1,0 +1,25 @@
+package com.example.concert.token.event;
+
+import com.example.concert.concert.event.ConcertSeatOccupyEvent;
+import com.example.concert.token.TokenFacade;
+import com.example.concert.token.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class TokenEventHandler {
+
+    private final TokenFacade tokenFacade;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void expireToken(ConcertSeatOccupyEvent concertSeatOccupyEvent) {
+        concertSeatOccupyEvent
+                .tokenString()
+                .ifPresent(this.tokenFacade::expireToken);
+    }
+}

--- a/week03_concert/src/main/resources/application-dev.yml
+++ b/week03_concert/src/main/resources/application-dev.yml
@@ -11,5 +11,14 @@ spring:
       port: 6379
 
   kafka:
+    bootstrap-servers: localhost:9092
+
+    consumer:
+      group-id: my-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
     producer:
-      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer

--- a/week03_concert/src/main/resources/application-dev.yml
+++ b/week03_concert/src/main/resources/application-dev.yml
@@ -9,3 +9,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092

--- a/week03_concert/src/main/resources/application-test.yml
+++ b/week03_concert/src/main/resources/application-test.yml
@@ -11,5 +11,14 @@ spring:
       port: 6379
 
   kafka:
+    bootstrap-servers: localhost:9092
+
+    consumer:
+      group-id: my-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
     producer:
-      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer

--- a/week03_concert/src/main/resources/application-test.yml
+++ b/week03_concert/src/main/resources/application-test.yml
@@ -9,3 +9,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092

--- a/week03_concert/src/test/java/com/example/concert/TestContainerConfig.java
+++ b/week03_concert/src/test/java/com/example/concert/TestContainerConfig.java
@@ -3,6 +3,7 @@ package com.example.concert;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration
@@ -15,6 +16,9 @@ public class TestContainerConfig {
     private static GenericContainer mariadb;
     private static final String MARIADB_IMAGE = "mariadb:11.5";
 
+    private static KafkaContainer kafka;
+    private static final String KAFKA_IMAGE = "apache/kafka";
+
     static {
         redis = new GenericContainer(DockerImageName.parse(REDIS_IMAGE))
                 .withExposedPorts(REDIS_PORT);
@@ -26,5 +30,9 @@ public class TestContainerConfig {
                 .withDatabaseName("concert")
                 .withUsername("username")
                 .withPassword("password");
+
+        kafka = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE));
+        kafka.start();
+        System.setProperty("spring.kafka.producer.bootstrap-servers", kafka.getBootstrapServers());
     }
 }

--- a/week03_concert/src/test/java/com/example/concert/TestContainerConfig.java
+++ b/week03_concert/src/test/java/com/example/concert/TestContainerConfig.java
@@ -33,6 +33,6 @@ public class TestContainerConfig {
 
         kafka = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE));
         kafka.start();
-        System.setProperty("spring.kafka.producer.bootstrap-servers", kafka.getBootstrapServers());
+        System.setProperty("spring.kafka.bootstrap-servers", kafka.getBootstrapServers());
     }
 }

--- a/week03_concert/src/test/java/com/example/concert/integration/EventTest.java
+++ b/week03_concert/src/test/java/com/example/concert/integration/EventTest.java
@@ -1,21 +1,17 @@
 package com.example.concert.integration;
 
 import com.example.concert.TestEnv;
-import com.example.concert.balance.BalanceFacade;
 import com.example.concert.concert.ConcertFacade;
 import com.example.concert.concert.domain.concert.Concert;
 import com.example.concert.concert.domain.concertseat.ConcertSeat;
 import com.example.concert.concert.domain.concerttimeslot.ConcertTimeslot;
-import com.example.concert.concert.event.ConcertSeatOccupyEvent;
 import com.example.concert.token.TokenFacade;
-import com.example.concert.token.event.TokenEventHandler;
 import com.example.concert.user.UserFacade;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,9 +23,7 @@ import static org.mockito.BDDMockito.*;
 @ExtendWith(MockitoExtension.class)
 public class EventTest extends TestEnv {
 
-    @SpyBean private TokenEventHandler tokenEventHandler;
-
-    @Autowired private TokenFacade tokenFacade;
+    @SpyBean private TokenFacade tokenFacade;
     @Autowired private ConcertFacade concertFacade;
     @Autowired private UserFacade userFacade;
 
@@ -60,7 +54,7 @@ public class EventTest extends TestEnv {
 
         // Then
         Thread.sleep(1000);
-        verify(tokenEventHandler, times(1))
-                .expireToken(any(ConcertSeatOccupyEvent.class));
+        verify(tokenFacade, times(1))
+                .expireToken(token.toString());
     }
 }

--- a/week03_concert/src/test/java/com/example/concert/integration/EventTest.java
+++ b/week03_concert/src/test/java/com/example/concert/integration/EventTest.java
@@ -8,6 +8,7 @@ import com.example.concert.concert.domain.concertseat.ConcertSeat;
 import com.example.concert.concert.domain.concerttimeslot.ConcertTimeslot;
 import com.example.concert.concert.event.ConcertSeatOccupyEvent;
 import com.example.concert.token.TokenFacade;
+import com.example.concert.token.event.TokenEventHandler;
 import com.example.concert.user.UserFacade;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,11 +27,11 @@ import static org.mockito.BDDMockito.*;
 @ExtendWith(MockitoExtension.class)
 public class EventTest extends TestEnv {
 
-    @SpyBean private TokenFacade tokenFacade;
+    @SpyBean private TokenEventHandler tokenEventHandler;
 
+    @Autowired private TokenFacade tokenFacade;
     @Autowired private ConcertFacade concertFacade;
     @Autowired private UserFacade userFacade;
-    @Autowired private ApplicationEventPublisher eventPublisher;
 
     @Test
     void tokenShouldExpire_afterConcertSeatOccupy() throws InterruptedException {
@@ -59,7 +60,7 @@ public class EventTest extends TestEnv {
 
         // Then
         Thread.sleep(1000);
-        verify(tokenFacade, times(1))
+        verify(tokenEventHandler, times(1))
                 .expireToken(any(ConcertSeatOccupyEvent.class));
     }
 }


### PR DESCRIPTION
_Application Event를 Kafka Message로 변경하는 내용은 step17에 포함시키고, step18은 TOP에 집중해서 정리했습니다_

> [!NOTE]
> Test Container 재시작 시간을 줄이기 위해 Redis와 MariaDB는 `@BeforeEach`에서 초기화되지만, Kafka는 초기화 로직이 없어 테스트 컨테이너를 매번 새로 생성해야 합니다. 그러나 이 과정이 시간이 너무 오래 걸려(10분 이상...) 현재 해당 로직을 제외한 상태입니다. 이로 인해 여러 테스트를 동시에 실행하면 실패할 수 있으나, 개별 실행 시에는 모두 통과하는 것을 확인했습니다.

# 카프카 적용

## 적용한 것
- 인프라 설정용 docker-compose에 Kafka 추가
- Test Container에 Kafka 추가 ~feat. 아고라~
- Kafka-Spring 연결 세팅
- Produce, Consume 확인
- Serializer 및 DeSerializer 설정하여 객체 매핑하기

### 카프카 적용
- 기존 Application Event를 Kafka로 교체
- infrastructure environment
  - dev : docker compose로 zookeeper-kafka 연결 설정
  - test : test container로 컨테이너 띄우고 spring property 설정
- 기존 테스트였던 [Event Test](https://github.com/JayHarrisonAhn/hhplus-assignment-tdd/blob/step17/week03_concert/src/test/java/com/example/concert/integration/EventTest.java)가 정상 작동하는 것 확인

### 테스트
- Kafka produce가 발생했을 때, consumer가 트리거되는 것을 확인

## 공부한 것
### 왜 메세지 큐를 사용해야 하는가?
- MSA에서 API를 사용할 경우
  - 서비스 간 직접 호출로 인해 의존성 높아짐
  - api별 통신방식 파편화되면 관리 힘들어짐
- MSA에서 메세지큐를 사용할 경우
  - Fire and Forget으로 결합도 낮아짐
  - 다만, 메세지 브로커 운영에 따른 복잡성이 존재
  - 보상 트랜잭션이 필요할 수 있음

### 카프카 특징
- 분산 메세지 큐
  - Fault Tolerant하다. - 분산 시스템이기 때문에 단일 인스턴스 장애에 대응 가능
  - Scalable하다. - 수평적 분산이 가능하다
- 브로커-토픽-파티션
  - 한 파티션 내부의 토픽들은 순서가 보장된다
  - 파티션을 늘리는 것은 되지만 반대는 사실상 불가능하다
- 빠르다
  - 메세지 큐 특성상 순차 읽기/쓰기 작업이 빠르다
  - OS의 sendFile함수로 Application Buffer를 거치지 않고 Zero Copy가 가능하다
![image](https://github.com/user-attachments/assets/51ac071a-5f05-4614-8127-6bab4cd37691)
